### PR TITLE
added width to cards container

### DIFF
--- a/fragments/cards/template.html
+++ b/fragments/cards/template.html
@@ -1,4 +1,4 @@
-<div class="flex flex-wrap -mx-3">
+<div class="flex flex-wrap -mx-3 w-full">
 
   <div class="card my-3 px-0 md:px-3">
     <div class="flex flex-col h-full">


### PR DESCRIPTION
Thanks for contributing to Peregrine CMS!

**What does this implement/fix? Explain your changes.**

fixes card container and cards not being width specified by editor

**Does this close any currently open issues?**

Yes issues.98

**Where has this been tested?**
added class in inspector and worked
<img width="1438" alt="Screen Shot 2020-05-08 at 1 01 12 PM" src="https://user-images.githubusercontent.com/49845255/81444448-02377980-912c-11ea-8854-56cd4bb42260.png">


*Brower (version):* Chrome

